### PR TITLE
Add rw lock instead

### DIFF
--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -591,10 +591,6 @@ var (
 	transformationIDsLock  sync.RWMutex                 // Using RWMutex instead of Mutex for better read performance
 )
 
-func init() {
-	transformationNameToID[""] = 0
-}
-
 func transformationID(currentID int, transformationName string) int {
 	// First try reading with read lock
 	transformationIDsLock.RLock()


### PR DESCRIPTION
before:

```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkTraceablePOSTFromCSV$ github.com/Traceableai/coraza-waf/cmd/coraza-waf-service

2025/01/21 18:01:27 maxprocs: Leaving GOMAXPROCS=10: CPU quota undefined
goos: darwin
goarch: amd64
pkg: github.com/Traceableai/coraza-waf/cmd/coraza-waf-service
cpu: VirtualApple @ 2.50GHz
BenchmarkTraceablePOSTFromCSV-10             158       9538749 ns/op     3554181 B/op      17324 allocs/op
PASS
ok      github.com/Traceableai/coraza-waf/cmd/coraza-waf-service    8.158s
```

After

```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkTraceablePOSTFromCSV$ github.com/Traceableai/coraza-waf/cmd/coraza-waf-service

2025/01/21 18:02:34 maxprocs: Leaving GOMAXPROCS=10: CPU quota undefined
goos: darwin
goarch: amd64
pkg: github.com/Traceableai/coraza-waf/cmd/coraza-waf-service
cpu: VirtualApple @ 2.50GHz
BenchmarkTraceablePOSTFromCSV-10             315       7484567 ns/op     3552452 B/op      17486 allocs/op
PASS
ok      github.com/Traceableai/coraza-waf/cmd/coraza-waf-service    21.369s
```
